### PR TITLE
Fix buildsystem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,0 @@
-_deps/
-CMakeFiles/
-CMakeCache.txt
-Makefile
-cmake_install.cmake
-finddups

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "extern/cxxopts"]
-	path = extern/cxxopts
-	url = https://github.com/jarro2783/cxxopts

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,13 +12,12 @@ include(FetchContent)
 FetchContent_Declare(cxxopts
   GIT_REPOSITORY     https://github.com/jarro2783/cxxopts
   GIT_TAG            v3.1.1)
-FetchContent_MakeAvailable(cxxopts)
 FetchContent_Declare(xxhash_cpp
   GIT_REPOSITORY     https://github.com/RedSpah/xxhash_cpp
   GIT_TAG            0.8.1)
-FetchContent_MakeAvailable(xxhash_cpp)
+FetchContent_MakeAvailable(cxxopts xxhash_cpp)
 
 add_executable(finddups finddups.cpp dehumanize.cpp)
 target_compile_features(finddups PRIVATE cxx_std_23)
 target_link_libraries(finddups PRIVATE cxxopts::cxxopts)
-target_include_directories(finddups PRIVATE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>)
+target_link_libraries(finddups PRIVATE xxhash_cpp)

--- a/finddups.cpp
+++ b/finddups.cpp
@@ -1,5 +1,5 @@
-#include "_deps/cxxopts-src/include/cxxopts.hpp"
-#include "_deps/xxhash_cpp-src/include/xxhash.hpp"
+#include <cxxopts.hpp>
+#include <xxhash.hpp>
 #include "dehumanize.h"
 #include <algorithm>
 #include <array>


### PR DESCRIPTION
Hey, meator here (from `#voidlinux`). You said that PRs are welcome, so here's one.

I myself don't know CMake that well, but I was able to fix your buildsystem.

Your current buildsystem doesn't support separate builddirs. Separate builddirs are a essential (and very practical) feature of most modern build systems (including CMake). I would recommend you reading more about them online.

In summary, you shouldn't run `cmake` in the source directory (like this: `cmake .`), but you should make a new directory (for example `build` in the root of the repo), `cd` into it and run `cmake ..` (or you can use the absolute path).

The advantage of this is that all things related to the build process will reside in that directory. These files won't pollute your code. This implements separation of build artifacts and code. This makes setting up multiple build environments very simple. You can for example create a `dbuilddir` (`d` for debug) subdirectory and setup CMake with flags tailored for debugging your program and a `rbuilddir` (`r` for release) subdirectory with all optimisations enabled.

Also, when there's something wrong with the build and you want to nuke it (this shouldn't be necessary, but you might want to do this sometimes), you can just run `rm -rf builddir/`.

Separate build dirs are the preferred way to build programs. Not using them is discouraged. For example, the Meson build system doesn't support building in the source directory (not because it wouldn't be possible, but because Meson doesn't want you to do this because of the disadvantages).

---
I have also fixed up the dependencies a bit (which in turn fixed separate builddirs). You shouldn't explicitly specify where the external header files are in your code, this is the build system's job. You might have noticed that my commits have simplified things. (`#include "_deps/cxxopts-src/include/cxxopts.hpp"` -> `#include <cxxopts.hpp>` and `target_include_directories(finddups PRIVATE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>)` got removed) This is usually a good sign. The old code was not only more complicated, but it also hindered the build system's ability to make separate builddirs. The simplest solution is usually the best.

In modern build systems, you usually just have to say "I want $library in my program" and the build system will download it, set up linking correctly and set up include dirs. `target_link_libraries()` does that (but I'm not an CMake expert; also `target_link_libraries()` doesn't download it, that's `FetchContent`'s job).